### PR TITLE
Add EOS into the Nexus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 examples/data
+build/phoenix/src
+build/reva/src
+build/eos-docker/src

--- a/build/phoenix/Dockerfile
+++ b/build/phoenix/Dockerfile
@@ -9,4 +9,4 @@ RUN yarn global add -D  webpack webpack-dev-server webpack-cli webpack-merge
 
 EXPOSE 8300
 
-RUN yarn install && yarn dist
+RUN yarn install && yarn dist && yarn 

--- a/build/reva/Dockerfile.eosprovider
+++ b/build/reva/Dockerfile.eosprovider
@@ -1,0 +1,19 @@
+# Build the reva code
+ARG GO_VERSION=1.11
+FROM golang:${GO_VERSION}
+#RUN apk add --no-cache --update alpine-sdk git ca-certificates gcc
+WORKDIR /src
+COPY ./src/go.mod ./src/go.sum ./
+RUN go mod download
+COPY ./src ./
+RUN CGO_ENABLE=0 cd cmd/revad && go build
+
+# Run the reva d contianer in a new image with eos binary / xrootd binary and auth tools
+FROM gitlab-registry.cern.ch/dss/eos:4.4.25
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+# Install LDAP PAM Tools / auth
+RUN useradd aaliyah_adams -p secret -u 1500
+# Add the revad binary from build image
+COPY --from=0 /src/cmd/revad/revad /src/cmd/revad/revad
+#RUN yum install -y nss-pam-ldapd nscd
+CMD ["/src/cmd/revad/revad -c /etc/revad/revad.toml"]

--- a/configs/Caddyfile
+++ b/configs/Caddyfile
@@ -21,7 +21,7 @@ owncloud.localhost:8443 {
 		transparent
 	}
 
-	proxy /phoenix/ phoenix:8300 {
+	proxy /phoenix/ phoenix:80 {
 		without /phoenix
                 transparent
 	}

--- a/configs/reva/storageprovider/eos.toml
+++ b/configs/reva/storageprovider/eos.toml
@@ -31,6 +31,7 @@ token_manager = "jwt"
 
 [grpc.interceptors.auth.methods]
 "/cs3.storageproviderv0alpha.StorageProviderService/Stat" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/List" = true
 
 [grpc.interceptors.auth.token_strategies.header]
 # TODO not needed? would need to be lowerase anyway
@@ -40,14 +41,9 @@ header = "X-Access-Token"
 secret = "Pive-Fumkiu4"
 
 [grpc.services.storageprovidersvc]
-driver = "local"
+driver = "eos"
 mount_path = "/"
 mount_id = "123e4567-e89b-12d3-a456-426655440000"
 
-[grpc.services.storageprovidersvc.drivers.local]
-root = "/data"
-
-[grpc.services.storageprovidersvc.eos]
-mgm = "root://nowhere.org"
-root_uid = 0
-root_gid = 0
+[grpc.services.storageprovidersvc.drivers.eos]
+master_url = "root://eos-mgm-test.eoscluster.cern.ch"

--- a/configs/reva/storageprovider/eos.toml
+++ b/configs/reva/storageprovider/eos.toml
@@ -30,8 +30,26 @@ token_strategy = "header"
 token_manager = "jwt"
 
 [grpc.interceptors.auth.methods]
+"/cs3.storageproviderv0alpha.StorageProviderService/CreateDirectory" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/Delete" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/Move" = true
 "/cs3.storageproviderv0alpha.StorageProviderService/Stat" = true
 "/cs3.storageproviderv0alpha.StorageProviderService/List" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/StartWriteSession" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/Write" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/FinishWriteSession" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/Read" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/ListVersions" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/ReadVersion" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/RestoreVersion" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/ListRecycle" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/RestoreRecycleItem" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/PurgeRecycle" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/SetACL" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/UpdateACL" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/UnsetACL" = true
+"/cs3.storageproviderv0alpha.StorageProviderService/GetQuota" = true
+
 
 [grpc.interceptors.auth.token_strategies.header]
 # TODO not needed? would need to be lowerase anyway

--- a/configs/reva/storageprovider/local.toml
+++ b/configs/reva/storageprovider/local.toml
@@ -1,0 +1,48 @@
+[core]
+log_file = "stderr"
+log_mode = "dev"
+max_cpus = "2"
+
+[grpc]
+network = "tcp"
+address = "0.0.0.0:9999"
+access_log = "stderr"
+#tls_enabled = true
+#tls_cert = "/etc/gridsecurity/host.cert"
+#tls_key = "/etc/gridsecurity/host.key"
+enabled_services = ["storageprovidersvc"]
+# TODO we need to authenticate the cs3 calls
+enabled_interceptors = ["auth", "log", "trace"]
+
+[grpc.interceptors.trace]
+priority = 100
+header = "x-trace"
+
+[grpc.interceptors.log]
+priority = 100
+
+[grpc.interceptors.auth]
+priority = 300
+# TODO grpc 'headers' are stored as google.golang.org/grpc/metadata ... needs better naming, this is too confusing
+# keys for grpc metadata are always lowercase, so interceptors headers need to use lowercase.
+header = "x-access-token"
+token_strategy = "header"
+token_manager = "jwt"
+
+[grpc.interceptors.auth.methods]
+"/cs3.storageproviderv0alpha.StorageProviderService/Stat" = true
+
+[grpc.interceptors.auth.token_strategies.header]
+# TODO not needed? would need to be lowerase anyway
+header = "X-Access-Token"
+
+[grpc.interceptors.auth.token_managers.jwt]
+secret = "Pive-Fumkiu4"
+
+[grpc.services.storageprovidersvc]
+driver = "eos"
+mount_path = "/"
+mount_id = "123e4567-e89b-12d3-a456-426655440000"
+
+[grpc.services.storageprovidersvc.drivers.local]
+root = "/data"

--- a/deploy/core.yml
+++ b/deploy/core.yml
@@ -18,11 +18,11 @@ services:
       - /var/lib/ldap
       - /etc/ldap/slapd.d
       - /container/service/slapd/assets/certs/
-      - ./examples/ldap/base.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/10-base.ldif
-    networks:
-      - ocis
+      - ../examples/ldap/base.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/10-base.ldif
     ports:
       - "8389:389"
+    networks:
+      - ocis
 
   # IDP
   konnectd:
@@ -42,9 +42,9 @@ services:
       LDAP_FILTER: "(objectClass=*)"
       IDENTIFIER_REGISTRATION_CONF: /etc/kopano/konnectd-identifier-registration.yaml
     volumes:
-      - ./configs/kopano/identifier-registration.yaml:/etc/kopano/konnectd-identifier-registration.yaml:ro
-      - ./configs/ssl/private-key.pem:/run/secrets/konnectd_signing_private_key:ro
-      - ./configs/kopano/konnectd-encryption-secret.key:/run/secrets/konnectd_encryption_secret:ro
+      - ../configs/kopano/identifier-registration.yaml:/etc/kopano/konnectd-identifier-registration.yaml:ro
+      - ../configs/ssl/private-key.pem:/run/secrets/konnectd_signing_private_key:ro
+      - ../configs/kopano/konnectd-encryption-secret.key:/run/secrets/konnectd_encryption_secret:ro
     depends_on:
     - openldap
     command:
@@ -55,44 +55,32 @@ services:
   # owncloud frontend
   phoenix:
     build:
-      context: ./build/phoenix
+      context: ../build/phoenix/src
       dockerfile: Dockerfile
     container_name: phoenix
     volumes:
-       - ./configs/phoenix/config.json:/app/config.json:ro
-    command: yarn run watch --allowed-hosts owncloud.localhost --host 0.0.0.0
+       - ../configs/phoenix/config.json:/usr/share/nginx/html/config.json:ro
     networks:
       - ocis
 
   # The meat of it
   ocdavsvc:
     build:
-      context: ./build/reva
+      context: ../build/reva
       dockerfile: Dockerfile
     container_name: ocdavsvc
     volumes:
-      - ./configs/reva/ocdavsvc.toml:/etc/revad/revad.toml
+      - ../configs/reva/ocdavsvc.toml:/etc/revad/revad.toml
     networks:
       - ocis
       
   authsvc:
     build:
-      context: ./build/reva
+      context: ../build/reva
       dockerfile: Dockerfile
     container_name: authsvc
     volumes:
-      - ./configs/reva/authsvc.toml:/etc/revad/revad.toml
-    networks:
-      - ocis
-      
-  storageprovidersvc:
-    build:
-      context: ./build/reva
-      dockerfile: Dockerfile
-    container_name: storageprovidersvc
-    volumes:
-      - ./configs/reva/storageprovidersvc.toml:/etc/revad/revad.toml
-      - ./examples/data:/data
+      - ../configs/reva/authsvc.toml:/etc/revad/revad.toml
     networks:
       - ocis
 
@@ -112,7 +100,7 @@ services:
     image: abiosoft/caddy:no-stats
     container_name: caddy
     volumes:
-      - ./configs/Caddyfile:/etc/Caddyfile
+      - ../configs/Caddyfile:/etc/Caddyfile
     ports:
       - "8443:8443"
     networks:

--- a/deploy/storage/eos.yml
+++ b/deploy/storage/eos.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  storageprovidersvc:
+    build:
+      context: ../build/reva
+      dockerfile: Dockerfile.eosprovider
+    container_name:  storageprovidersvc
+    volumes:
+      - ../configs/reva/storageprovider/eos.toml:/etc/revad/revad.toml
+    networks:
+      # For XrootD communication to EOS MGM5
+      - eoscluster.cern.ch
+      - ocis
+networks:
+  # External network used in demo eos cluster setup 
+  eoscluster.cern.ch:
+    external: true

--- a/deploy/storage/local.yml
+++ b/deploy/storage/local.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  storageprovidersvc:
+    build:
+      context: ../../build/reva
+      dockerfile: Dockerfile
+    container_name: storageprovidersvc
+    volumes:
+      - ../../configs/reva/storageprovider/local.toml:/etc/revad/revad.toml
+      - ../../examples/data:/data
+    networks:
+      - ocis
+networks:
+  ocis:


### PR DESCRIPTION
🚀 

- `make future` now spins up an EOS cluster to use with Nexus. 
 - `make down` will close all containers including EOS cluster
 - `make logs` will tail all container logs in terminal
 - Separated the storage provider compose files to allow different configurations for local / EOS
 - Makefile clones https://gitlab.cern.ch/eos/eos-docker to use for demo cluster
 - Use Dockerfile provided by phoenix to avoid rebuild each restart
 - Ignore source files from dependencies

 - Adds a single user, `aaliyah_adams` with unix uid 1500

TODO:

 - [ ] Create static user(s) on EOS mgm as well after creation
 - [ ] Setup FS on FST and fix mount point
